### PR TITLE
rename call-logs and stat pid file

### DIFF
--- a/bin/wazo-migrate-db-96-to-11
+++ b/bin/wazo-migrate-db-96-to-11
@@ -14,7 +14,7 @@ cluster_exists() {
 stop_services() {
 	echo "Stopping services..."
 	service cron stop
-	for pid_file in /run/xivo-call-logs.pid /run/xivo-stat.pid; do
+	for pid_file in /run/xivo-call-logs.pid /run/xivo-stat.pid /run/wazo-call-logs.pid /run/wazo-stat.pid; do
 		pid=$(cat "$pid_file" 2>/dev/null)
 		if [ -n "$pid" ]; then
 			kill $pid


### PR DESCRIPTION
reason: in really rare scenario, call-logs or stat command can be
triggered during upgrade or db upgrade can be done in a second time (if
there are errors).

It cost nothing to add verification here and it will avoid to think
about if it's right to use only xivo prefix since these services are
renamed