### PR TITLE
remove unused plpython dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,7 @@ Replaces: xivo-dbms
 Depends:
  ${misc:Depends},
  postgresql-11,
- postgresql-contrib-11,
- postgresql-plpython-11
+ postgresql-contrib-11
 Description: Wazo database management system
  Wazo is a system based on a powerful IPBX, to bring an easy to
  install solution for telephony and related services.


### PR DESCRIPTION
why: wazo is now only compatible with python3 and this dependency is
python2. It's a proof that is not used anymore