### PR TITLE
Add condition to append jit option to file if it does not exist already

### DIFF
--- a/bin/wazo-pg-config-update
+++ b/bin/wazo-pg-config-update
@@ -2,7 +2,12 @@
 
 POSTGRESQL_CONFIG='/etc/postgresql/13/main/postgresql.conf'
 
-sed -i -E "s/#?jit = (on|off)/jit = off/" "${POSTGRESQL_CONFIG}"
+if grep -q "jit =" "${POSTGRESQL_CONFIG}"; then
+  sed -i -E "s/#?jit = (on|off)/jit = off/" "${POSTGRESQL_CONFIG}"
+else
+  echo "jit = off" >> "${POSTGRESQL_CONFIG}"
+fi
+
 
 if /usr/bin/wazo-pg-is-running; then
   systemctl reload postgresql


### PR DESCRIPTION
reason: During postgresql updates the file is not always updated so the option may not be there and the sed will not work