### PR TITLE
specify postgres version for systemd reload

### DIFF
--- a/bin/wazo-pg-config-update
+++ b/bin/wazo-pg-config-update
@@ -10,5 +10,5 @@ fi
 
 
 if /usr/bin/wazo-pg-is-running; then
-  systemctl reload postgresql
+  systemctl reload postgresql@13-main
 fi


### PR DESCRIPTION
why: to avoid any confusion and be consistent with wazo-service