### PR TITLE
postgres: increase limit of maximum connections

### DIFF
--- a/debian/wazo-dbms.postinst
+++ b/debian/wazo-dbms.postinst
@@ -3,19 +3,10 @@
 set -e
 
 is_pg_cluster_online() {
-    local version="$1"
+    version="$1"
 
     # pg_ctlcluster exit with 0 only if the specified cluster is running
     pg_ctlcluster "$version" main status >/dev/null 2>&1
-}
-
-update_timezone() {
-    if ! timezone=$(pg_conftool -s 13 main postgresql.conf show timezone) || [ "$timezone" != 'localtime' ]; then
-        pg_conftool 13 main postgresql.conf set timezone localtime
-        if is_pg_cluster_online 13; then
-            pg_ctlcluster 13 main reload || true
-        fi
-    fi
 }
 
 case "$1" in
@@ -36,17 +27,19 @@ case "$1" in
 
         # the condition can't be more precise because the package did not exist previously
         if [ -z "$previous_version" ]; then
-            update_timezone
-        fi
-
-        /usr/bin/wazo-pg-config-update
-
-        # apply changes to postgresql max_connections
-        if dpkg --compare-versions "${previous_version}" lt '24.11'; then
+            # apply changes from conf.d drop-in
             if is_pg_cluster_online 13; then
                 pg_ctlcluster 13 main restart
             fi
+        else
+            # apply changes to max_connections
+            if dpkg --compare-versions "${previous_version}" lt '24.11'; then
+                if is_pg_cluster_online 13; then
+                    pg_ctlcluster 13 main restart
+                fi
+            fi
         fi
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/wazo-dbms.postinst
+++ b/debian/wazo-dbms.postinst
@@ -40,6 +40,13 @@ case "$1" in
         fi
 
         /usr/bin/wazo-pg-config-update
+
+        # apply changes to postgresql max_connections
+        if dpkg --compare-versions "${previous_version}" lt '24.11'; then
+            if is_pg_cluster_online 13; then
+                pg_ctlcluster 13 main restart
+            fi
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/etc/postgresql/13/main/conf.d/50-wazo-max-connections.conf
+++ b/etc/postgresql/13/main/conf.d/50-wazo-max-connections.conf
@@ -1,0 +1,1 @@
+max_connections = 2048

--- a/etc/postgresql/13/main/conf.d/50-wazo-max-connections.conf
+++ b/etc/postgresql/13/main/conf.d/50-wazo-max-connections.conf
@@ -1,1 +1,3 @@
-max_connections = 2048
+jit = off
+max_connections = 2048  # (change requires restart)
+timezone = localtime


### PR DESCRIPTION
Why:

* Default Wazo configuration uses at least 125 connections
* Avoid modifying it again in high-load environments